### PR TITLE
fix(provider): 处理配置类型为空时抛出异常的问题

### DIFF
--- a/src/provider/CLIProfileProvider.cpp
+++ b/src/provider/CLIProfileProvider.cpp
@@ -344,8 +344,9 @@ std::unique_ptr<Provider> CLIProfileProvider::createProvider() const {
 
   // 根据类型创建对应的 Provider
   auto configType = config->getType();
+  if (configType.empty()) {
     throw CredentialException(std::string("The configured client type is empty"));
-
+  }
   if (configType == Constant::ECS_RAM_ROLE) {
     return std::unique_ptr<Provider>(new EcsRamRoleProvider(config));
   } else if (configType == Constant::RSA_KEY_PAIR) {

--- a/tests/test_cli_profile_provider.cpp
+++ b/tests/test_cli_profile_provider.cpp
@@ -141,3 +141,49 @@ TEST_F(CLIProfileProviderTest, SupportsMultipleGetCredentialCalls) {
     provider.getCredential();
   }, CredentialException);
 }
+
+// mode 字段缺失 -> type 为空 -> createProvider() 抛出 "The configured client type is empty"
+TEST_F(CLIProfileProviderTest, EmptyModeThrowsCredentialException) {
+  std::string tmpPath = "/tmp/test_cli_empty_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"access_key_id\":\"test_id\",\"access_key_secret\":\"test_secret\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  try {
+    provider.getCredential();
+    FAIL() << "Expected CredentialException";
+  } catch (const CredentialException &e) {
+    EXPECT_NE(std::string(e.what()).find("type"), std::string::npos)
+        << "Expected error about empty type, got: " << e.what();
+  }
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=AK 且凭证齐全 -> 成功创建 AccessKeyProvider，getProviderName 不抛异常
+TEST_F(CLIProfileProviderTest, AkModeCreatesAccessKeyProvider) {
+  std::string tmpPath = "/tmp/test_cli_ak_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"AK\","
+      << "\"access_key_id\":\"test_ak_id\",\"access_key_secret\":\"test_ak_secret\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  EXPECT_NO_THROW({
+    std::string name = provider.getProviderName();
+    EXPECT_FALSE(name.empty());
+  });
+
+  std::remove(tmpPath.c_str());
+}

--- a/tests/test_cli_profile_provider.cpp
+++ b/tests/test_cli_profile_provider.cpp
@@ -142,9 +142,23 @@ TEST_F(CLIProfileProviderTest, SupportsMultipleGetCredentialCalls) {
   }, CredentialException);
 }
 
+// 获取跨平台的临时目录路径
+static std::string getTempDir() {
+#if defined(_WIN32) || defined(_WIN64)
+  const char* temp = std::getenv("TEMP");
+  if (!temp) temp = std::getenv("TMP");
+  if (!temp) temp = "C:\\Windows\\Temp";
+  return std::string(temp);
+#else
+  const char* tmpdir = std::getenv("TMPDIR");
+  if (tmpdir) return std::string(tmpdir);
+  return "/tmp";
+#endif
+}
+
 // mode 字段缺失 -> type 为空 -> createProvider() 抛出 "The configured client type is empty"
 TEST_F(CLIProfileProviderTest, EmptyModeThrowsCredentialException) {
-  std::string tmpPath = "/tmp/test_cli_empty_mode.json";
+  std::string tmpPath = getTempDir() + "/test_cli_empty_mode.json";
   {
     std::ofstream f(tmpPath);
     f << "{\"current\":\"default\",\"profiles\":["
@@ -168,7 +182,7 @@ TEST_F(CLIProfileProviderTest, EmptyModeThrowsCredentialException) {
 
 // mode=AK 且凭证齐全 -> 成功创建 AccessKeyProvider，getProviderName 不抛异常
 TEST_F(CLIProfileProviderTest, AkModeCreatesAccessKeyProvider) {
-  std::string tmpPath = "/tmp/test_cli_ak_mode.json";
+  std::string tmpPath = getTempDir() + "/test_cli_ak_mode.json";
   {
     std::ofstream f(tmpPath);
     f << "{\"current\":\"default\",\"profiles\":["


### PR DESCRIPTION
- 在CLIProfileProvider::createProvider添加空类型判断，抛出CredentialException异常
- 修正代码格式，确保空类型判断括号匹配
- 增加测试用例覆盖类型为空时抛出异常的场景
- 增加测试用例验证mode=AK且凭证完整时正确创建AccessKeyProvider
- 增加测试用例确保getProviderName方法正常执行且不抛异常