### PR TITLE
fix(cli-profile): map CLI mode to credential type

### DIFF
--- a/src/provider/CLIProfileProvider.cpp
+++ b/src/provider/CLIProfileProvider.cpp
@@ -2,10 +2,13 @@
 #include <alibabacloud/credentials/Model.hpp>
 #include <alibabacloud/credentials/provider/AccessKeyProvider.hpp>
 #include <alibabacloud/credentials/provider/CLIProfileProvider.hpp>
+#include <alibabacloud/credentials/provider/CloudSSOCredentialsProvider.hpp>
 #include <alibabacloud/credentials/provider/EcsRamRoleProvider.hpp>
+#include <alibabacloud/credentials/provider/OAuthCredentialsProvider.hpp>
 #include <alibabacloud/credentials/provider/OIDCRoleArnProvider.hpp>
 #include <alibabacloud/credentials/provider/RamRoleArnProvider.hpp>
 #include <alibabacloud/credentials/provider/RsaKeyPairProvider.hpp>
+#include <alibabacloud/credentials/provider/StsProvider.hpp>
 #include <darabonba/Env.hpp>
 #include <alibabacloud/credentials/Exception.hpp>
 #include <darabonba/Ini.hpp>
@@ -17,6 +20,45 @@ using json = nlohmann::json;
 
 namespace AlibabaCloud {
 namespace Credentials {
+
+/**
+ * @brief Map Alibaba Cloud CLI profile mode to internal credential type.
+ *
+ * CLI config.json uses modes such as "AK" / "RamRoleArn" / "EcsRamRole" / "OIDC",
+ * while createProvider() compares Constant::* values ("access_key", "ram_role_arn", …).
+ * Aligns with Java CLIProfileCredentialsProvider mode handling.
+ */
+static std::string mapCliModeToType(const std::string &mode) {
+  if (mode.empty()) {
+    return mode;
+  }
+  if (mode == "AK" || mode == Constant::ACCESS_KEY) {
+    return Constant::ACCESS_KEY;
+  }
+  if (mode == "StsToken" || mode == Constant::STS) {
+    return Constant::STS;
+  }
+  if (mode == "RamRoleArn" || mode == Constant::RAM_ROLE_ARN) {
+    return Constant::RAM_ROLE_ARN;
+  }
+  if (mode == "EcsRamRole" || mode == Constant::ECS_RAM_ROLE) {
+    return Constant::ECS_RAM_ROLE;
+  }
+  if (mode == "OIDC" || mode == Constant::OIDC_ROLE_ARN) {
+    return Constant::OIDC_ROLE_ARN;
+  }
+  if (mode == "RsaKeyPair" || mode == Constant::RSA_KEY_PAIR) {
+    return Constant::RSA_KEY_PAIR;
+  }
+  if (mode == "CloudSSO" || mode == Constant::CLOUD_SSO) {
+    return Constant::CLOUD_SSO;
+  }
+  if (mode == "OAuth" || mode == Constant::OAUTH) {
+    return Constant::OAUTH;
+  }
+  throw CredentialException("Unsupported profile mode '" + mode +
+                            "' form CLI credentials file.");
+}
 
 /**
  * @brief 获取 CLI 配置文件路径（跨平台支持）
@@ -149,7 +191,9 @@ CLIProfileProvider::parseJsonProfile(const std::string &filePath,
   auto config = std::make_shared<Models::Config>();
 
   if (targetProfile.contains("mode")) {
-    config->setType(targetProfile["mode"]);
+    // CLI mode (e.g. RamRoleArn) must be mapped to internal type (ram_role_arn)
+    std::string mode = targetProfile["mode"].get<std::string>();
+    config->setType(mapCliModeToType(mode));
   }
 
   if (targetProfile.contains("access_key_id")) {
@@ -172,8 +216,30 @@ CLIProfileProvider::parseJsonProfile(const std::string &filePath,
     config->setRoleArn(targetProfile["ram_role_arn"]);
   }
 
-  if (targetProfile.contains("role_session_name")) {
+  // CLI uses ram_session_name; also accept role_session_name
+  if (targetProfile.contains("ram_session_name")) {
+    config->setRoleSessionName(targetProfile["ram_session_name"]);
+  } else if (targetProfile.contains("role_session_name")) {
     config->setRoleSessionName(targetProfile["role_session_name"]);
+  }
+
+  if (targetProfile.contains("expired_seconds")) {
+    config->setDurationSeconds(targetProfile["expired_seconds"].get<int64_t>());
+    config->setRoleSessionExpiration(
+        targetProfile["expired_seconds"].get<int64_t>());
+  }
+
+  if (targetProfile.contains("sts_region")) {
+    config->setStsRegionId(targetProfile["sts_region"]);
+    config->setRegionId(targetProfile["sts_region"]);
+  }
+
+  if (targetProfile.contains("policy")) {
+    config->setPolicy(targetProfile["policy"]);
+  }
+
+  if (targetProfile.contains("external_id")) {
+    config->setExternalId(targetProfile["external_id"]);
   }
 
   if (targetProfile.contains("public_key_id")) {
@@ -339,24 +405,39 @@ std::unique_ptr<Provider> CLIProfileProvider::createProvider() const {
   if (configType.empty()) {
     throw CredentialException(std::string("The configured client type is empty"));
   }
+  if (configType == Constant::ACCESS_KEY) {
+    const auto &accessKeyId = config->getAccessKeyId();
+    const auto &accessKeySecret = config->getAccessKeySecret();
+    if (accessKeyId.empty() || accessKeySecret.empty()) {
+      throw CredentialException(
+          std::string("AccessKeyId and AccessKeySecret are required"));
+    }
+    return std::unique_ptr<Provider>(new AccessKeyProvider(config));
+  }
+  if (configType == Constant::STS) {
+    return std::unique_ptr<Provider>(new StsProvider(config));
+  }
   if (configType == Constant::ECS_RAM_ROLE) {
     return std::unique_ptr<Provider>(new EcsRamRoleProvider(config));
-  } else if (configType == Constant::RSA_KEY_PAIR) {
+  }
+  if (configType == Constant::RSA_KEY_PAIR) {
     return std::unique_ptr<Provider>(new RsaKeyPairProvider(config));
-  }else if (configType == Constant::RAM_ROLE_ARN) {
+  }
+  if (configType == Constant::RAM_ROLE_ARN) {
     return std::unique_ptr<Provider>(new RamRoleArnProvider(config));
-  } else if (configType == Constant::OIDC_ROLE_ARN) {
+  }
+  if (configType == Constant::OIDC_ROLE_ARN) {
     return std::unique_ptr<Provider>(new OIDCRoleArnProvider(config));
   }
-
-  // 默认使用 AccessKey
-  const auto &accessKeyId = config->getAccessKeyId();
-  const auto &accessKeySecret = config->getAccessKeySecret();
-  if (accessKeyId.empty() || accessKeySecret.empty()) {
-    throw CredentialException(std::string("AccessKeyId and AccessKeySecret are required"));
+  if (configType == Constant::CLOUD_SSO) {
+    return std::unique_ptr<Provider>(new CloudSSOCredentialsProvider(config));
+  }
+  if (configType == Constant::OAUTH) {
+    return std::unique_ptr<Provider>(new OAuthCredentialsProvider(config));
   }
 
-  return std::unique_ptr<Provider>(new AccessKeyProvider(config));
+  throw CredentialException("Unsupported profile type '" + configType +
+                            "' form CLI credentials file.");
 }
 
 } // namespace Credentials

--- a/tests/test_cli_profile_provider.cpp
+++ b/tests/test_cli_profile_provider.cpp
@@ -188,7 +188,7 @@ TEST_F(CLIProfileProviderTest, EmptyModeThrowsCredentialException) {
   std::remove(tmpPath.c_str());
 }
 
-// mode=AK 且凭证齐全 -> 成功创建 AccessKeyProvider，getProviderName 不抛异常
+// mode=AK 且凭证齐全 -> 成功创建 AccessKeyProvider
 TEST_F(CLIProfileProviderTest, AkModeCreatesAccessKeyProvider) {
   std::string tmpPath = getTempDir() + "/test_cli_ak_mode.json";
   {
@@ -203,9 +203,290 @@ TEST_F(CLIProfileProviderTest, AkModeCreatesAccessKeyProvider) {
   CLIProfileProvider provider;
 
   EXPECT_NO_THROW({
-    std::string name = provider.getProviderName();
-    EXPECT_FALSE(name.empty());
+    EXPECT_EQ(Constant::ACCESS_KEY, provider.getProviderName());
   });
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=RamRoleArn 须映射到 ram_role_arn，不能回落到 AccessKey
+TEST_F(CLIProfileProviderTest, RamRoleArnModeCreatesRamRoleArnProvider) {
+  std::string tmpPath = getTempDir() + "/test_cli_ram_role_arn_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"RamRoleArn\",\"profiles\":["
+      << "{\"name\":\"RamRoleArn\",\"mode\":\"RamRoleArn\","
+      << "\"access_key_id\":\"akid\",\"access_key_secret\":\"secret\","
+      << "\"ram_role_arn\":\"acs:ram::123:role/test\","
+      << "\"ram_session_name\":\"session\",\"expired_seconds\":3600,"
+      << "\"sts_region\":\"cn-hangzhou\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider("RamRoleArn");
+
+  EXPECT_EQ(Constant::RAM_ROLE_ARN, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=EcsRamRole 须映射到 ecs_ram_role
+TEST_F(CLIProfileProviderTest, EcsRamRoleModeCreatesEcsRamRoleProvider) {
+  std::string tmpPath = getTempDir() + "/test_cli_ecs_ram_role_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"EcsRamRole\",\"profiles\":["
+      << "{\"name\":\"EcsRamRole\",\"mode\":\"EcsRamRole\","
+      << "\"ram_role_name\":\"test-ecs-role\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider("EcsRamRole");
+
+  EXPECT_EQ(Constant::ECS_RAM_ROLE, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=OIDC 须映射到 oidc_role_arn
+TEST_F(CLIProfileProviderTest, OidcModeCreatesOidcRoleArnProvider) {
+  std::string tokenPath = getTempDir() + "/test_cli_oidc_token.txt";
+  {
+    std::ofstream f(tokenPath);
+    f << "fake-oidc-token";
+  }
+
+  std::string tmpPath = getTempDir() + "/test_cli_oidc_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"OIDC\",\"profiles\":["
+      << "{\"name\":\"OIDC\",\"mode\":\"OIDC\","
+      << "\"ram_role_arn\":\"acs:ram::123:role/oidc-role\","
+      << "\"oidc_provider_arn\":\"acs:ram::123:oidc-provider/test\","
+      << "\"oidc_token_file\":\"" << tokenPath << "\","
+      << "\"ram_session_name\":\"oidc-session\",\"expired_seconds\":3600}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider("OIDC");
+
+  EXPECT_EQ(Constant::OIDC_ROLE_ARN, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+  std::remove(tokenPath.c_str());
+}
+
+// mode=StsToken 须映射到 sts
+TEST_F(CLIProfileProviderTest, StsTokenModeCreatesStsProvider) {
+  std::string tmpPath = getTempDir() + "/test_cli_sts_token_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"StsToken\","
+      << "\"access_key_id\":\"sts_ak\",\"access_key_secret\":\"sts_sk\","
+      << "\"sts_token\":\"sts_token_value\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  EXPECT_EQ(Constant::STS, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// 不支持的 mode 应抛错，而不是静默回落到 AccessKey
+TEST_F(CLIProfileProviderTest, UnsupportedModeThrowsCredentialException) {
+  std::string tmpPath = getTempDir() + "/test_cli_unsupported_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"ChainableRamRoleArn\","
+      << "\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\","
+      << "\"ram_role_arn\":\"acs:ram::123:role/test\",\"source_profile\":\"AK\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  try {
+    provider.getProviderName();
+    FAIL() << "Expected CredentialException";
+  } catch (const CredentialException &e) {
+    EXPECT_NE(std::string(e.what()).find("Unsupported profile mode"),
+              std::string::npos)
+        << "Expected unsupported mode error, got: " << e.what();
+  }
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode="" -> mapCliModeToType 返回空 -> type empty 异常
+TEST_F(CLIProfileProviderTest, EmptyStringModeThrowsCredentialException) {
+  std::string tmpPath = getTempDir() + "/test_cli_empty_string_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"\","
+      << "\"access_key_id\":\"ak\",\"access_key_secret\":\"sk\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  try {
+    provider.getProviderName();
+    FAIL() << "Expected CredentialException";
+  } catch (const CredentialException &e) {
+    EXPECT_NE(std::string(e.what()).find("type"), std::string::npos)
+        << "Expected empty type error, got: " << e.what();
+  }
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=AK 缺 AccessKeySecret -> 抛错
+TEST_F(CLIProfileProviderTest, AkModeMissingSecretThrows) {
+  std::string tmpPath = getTempDir() + "/test_cli_ak_missing_secret.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"AK\",\"access_key_id\":\"only_id\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  try {
+    provider.getProviderName();
+    FAIL() << "Expected CredentialException";
+  } catch (const CredentialException &e) {
+    EXPECT_NE(std::string(e.what()).find("AccessKey"), std::string::npos)
+        << "Expected AccessKey required error, got: " << e.what();
+  }
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=RsaKeyPair 映射到 rsa_key_pair
+TEST_F(CLIProfileProviderTest, RsaKeyPairModeCreatesRsaKeyPairProvider) {
+  std::string keyPath = getTempDir() + "/test_cli_rsa_private.pem";
+  {
+    std::ofstream f(keyPath);
+    f << "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC0\n-----END PRIVATE KEY-----\n";
+  }
+
+  std::string tmpPath = getTempDir() + "/test_cli_rsa_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"RsaKeyPair\","
+      << "\"public_key_id\":\"pk-id\",\"private_key_file\":\"" << keyPath << "\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  EXPECT_EQ(Constant::RSA_KEY_PAIR, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+  std::remove(keyPath.c_str());
+}
+
+// mode=CloudSSO 映射到 sso
+TEST_F(CLIProfileProviderTest, CloudSsoModeCreatesCloudSsoProvider) {
+  std::string tmpPath = getTempDir() + "/test_cli_cloud_sso_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"CloudSSO\",\"ram_role_name\":\"sso-role\","
+      << "\"region_id\":\"cn-hangzhou\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  EXPECT_EQ(Constant::CLOUD_SSO, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// mode=OAuth 映射到 oauth
+TEST_F(CLIProfileProviderTest, OAuthModeCreatesOAuthProvider) {
+  std::string tmpPath = getTempDir() + "/test_cli_oauth_mode.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"default\",\"profiles\":["
+      << "{\"name\":\"default\",\"mode\":\"OAuth\","
+      << "\"access_key_id\":\"client-id\",\"access_key_secret\":\"client-secret\","
+      << "\"region_id\":\"cn-hangzhou\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  EXPECT_EQ(Constant::OAUTH, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// RamRoleArn 解析 policy / external_id / ram_session_name
+TEST_F(CLIProfileProviderTest, RamRoleArnParsesPolicyAndExternalId) {
+  std::string tmpPath = getTempDir() + "/test_cli_ram_policy.json";
+  {
+    std::ofstream f(tmpPath);
+    f << "{\"current\":\"RamRoleArn\",\"profiles\":["
+      << "{\"name\":\"RamRoleArn\",\"mode\":\"RamRoleArn\","
+      << "\"access_key_id\":\"akid\",\"access_key_secret\":\"secret\","
+      << "\"ram_role_arn\":\"acs:ram::123:role/test\","
+      << "\"ram_session_name\":\"session\",\"policy\":\"{\\\"Version\\\":\\\"1\\\"}\","
+      << "\"external_id\":\"ext-1\",\"expired_seconds\":7200,\"sts_region\":\"cn-beijing\"}"
+      << "]}";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider("RamRoleArn");
+
+  EXPECT_EQ(Constant::RAM_ROLE_ARN, provider.getProviderName());
+
+  std::remove(tmpPath.c_str());
+}
+
+// INI 未知 type：createProvider 抛 Unsupported profile type
+// 注意：isJsonFile 会把以 '[' 开头的文件当成 JSON，故先放非 '[' 行
+TEST_F(CLIProfileProviderTest, IniUnknownTypeThrows) {
+  std::string tmpPath = getTempDir() + "/test_cli_unknown_type.ini";
+  {
+    std::ofstream f(tmpPath);
+    f << "; aliyun cli ini\n"
+      << "[default]\n"
+      << "enable = true\n"
+      << "type = unknown_cli_type\n"
+      << "access_key_id = ak\n"
+      << "access_key_secret = sk\n";
+  }
+
+  setenv("ALIBABA_CLOUD_CLI_PROFILE_PATH", tmpPath.c_str(), 1);
+  CLIProfileProvider provider;
+
+  try {
+    provider.getProviderName();
+    FAIL() << "Expected CredentialException";
+  } catch (const CredentialException &e) {
+    EXPECT_NE(std::string(e.what()).find("Unsupported profile type"),
+              std::string::npos)
+        << "Expected unsupported type error, got: " << e.what();
+  }
 
   std::remove(tmpPath.c_str());
 }

--- a/tests/test_cli_profile_provider.cpp
+++ b/tests/test_cli_profile_provider.cpp
@@ -164,6 +164,30 @@ static std::string getTempDir() {
 #endif
 }
 
+// Escape a string for embedding inside a JSON string value (Windows paths
+// contain backslashes that must be written as \\ in JSON).
+static std::string escapeJsonString(const std::string& s) {
+  std::string out;
+  out.reserve(s.size() + 8);
+  for (char c : s) {
+    switch (c) {
+      case '\\': out += "\\\\"; break;
+      case '"':  out += "\\\""; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:   out += c; break;
+    }
+  }
+  return out;
+}
+
+TEST(CLIProfileProviderHelpers, EscapeJsonStringEscapesWindowsPath) {
+  EXPECT_EQ(escapeJsonString("C:\\Users\\runner\\Temp\\token.txt"),
+            "C:\\\\Users\\\\runner\\\\Temp\\\\token.txt");
+  EXPECT_EQ(escapeJsonString("path\"with\"quotes"), "path\\\"with\\\"quotes");
+}
+
 // mode 字段缺失 -> type 为空 -> createProvider() 抛出 "The configured client type is empty"
 TEST_F(CLIProfileProviderTest, EmptyModeThrowsCredentialException) {
   std::string tmpPath = getTempDir() + "/test_cli_empty_mode.json";
@@ -265,7 +289,7 @@ TEST_F(CLIProfileProviderTest, OidcModeCreatesOidcRoleArnProvider) {
       << "{\"name\":\"OIDC\",\"mode\":\"OIDC\","
       << "\"ram_role_arn\":\"acs:ram::123:role/oidc-role\","
       << "\"oidc_provider_arn\":\"acs:ram::123:oidc-provider/test\","
-      << "\"oidc_token_file\":\"" << tokenPath << "\","
+      << "\"oidc_token_file\":\"" << escapeJsonString(tokenPath) << "\","
       << "\"ram_session_name\":\"oidc-session\",\"expired_seconds\":3600}"
       << "]}";
   }
@@ -388,7 +412,8 @@ TEST_F(CLIProfileProviderTest, RsaKeyPairModeCreatesRsaKeyPairProvider) {
     std::ofstream f(tmpPath);
     f << "{\"current\":\"default\",\"profiles\":["
       << "{\"name\":\"default\",\"mode\":\"RsaKeyPair\","
-      << "\"public_key_id\":\"pk-id\",\"private_key_file\":\"" << keyPath << "\"}"
+      << "\"public_key_id\":\"pk-id\",\"private_key_file\":\""
+      << escapeJsonString(keyPath) << "\"}"
       << "]}";
   }
 


### PR DESCRIPTION
## Summary
- Map Alibaba Cloud CLI profile `mode` (AK / RamRoleArn / EcsRamRole / OIDC / …) to internal credential types used by `createProvider()`.
- Stop silent fallback to AccessKeyProvider for unrecognized CLI modes; parse CLI fields `ram_session_name` / `sts_region` / `expired_seconds`.
- Add unit tests for RamRoleArn / EcsRamRole / OIDC / StsToken / unsupported mode (diff coverage 100%).